### PR TITLE
Use Pyglet 1.2 for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ http://www.youtube.com/watch?v=kC3lwK631X8
     cd Minecraft
     python main.py
 
-Pyglet 1.1.4 can't run in 64-bit mode. Using Pyglet 1.2 fixes this problem.
+
+On Mac OS X, you may have an issue with running Pyglet in 64-bit mode. Try this running python in 32-bit mode first.
+
+    arch -i386 python main.py
+
+or try Pyglet 1.2 which supports 64-bit mode
 
     pip install https://pyglet.googlecode.com/files/pyglet-1.2alpha1.tar.gz 
+
+


### PR DESCRIPTION
Pyglet 1.2 fixes all of the issues for OS X and is compatible with 1.1.4
