### PR TITLE
Fixed "ZeroDivisionError: float division by zero" when minimized adding simple "ifs" on def set_2d and def set_3d

### DIFF
--- a/main.py
+++ b/main.py
@@ -410,7 +410,10 @@ class Window(pyglet.window.Window):
         glViewport(0, 0, width, height)
         glMatrixMode(GL_PROJECTION)
         glLoadIdentity()
-        glOrtho(0, width, 0, height, -1, 1)
+        if width != 0:
+            glOrtho(0, width, 0, height, -1, 1)
+        else:
+            glOrtho(0, 1, 0, 1, -1, 1)
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
     def set_3d(self):
@@ -419,7 +422,10 @@ class Window(pyglet.window.Window):
         glViewport(0, 0, width, height)
         glMatrixMode(GL_PROJECTION)
         glLoadIdentity()
-        gluPerspective(65.0, width / float(height), 0.1, 60.0)
+        if width != float(height):
+            gluPerspective(65.0, width / float(height), 0.1, 60.0)
+        else:
+            gluPerspective(65.0, 1, 0.1, 60.0)
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         x, y = self.rotation


### PR DESCRIPTION
Fixed "ZeroDivisionError: float division by zero" when minimized.
Traceback (most recent call last):
  File "MCMain.py", line 484, in <module>
    main()
  File "MCMain.py", line 481, in main
    pyglet.app.run()
  File "C:\Python27\lib\site-packages\pyglet\app__init__.py", line 264, in run
    EventLoop().run()
  File "C:\Python27\lib\site-packages\pyglet\app\win32.py", line 63, in run
    self._timer_func(0, 0, timer, 0)
  File "C:\Python27\lib\site-packages\pyglet\app\win32.py", line 84, in _timer_func
    sleep_time = self.idle()
  File "C:\Python27\lib\site-packages\pyglet\app__init__.py", line 193, in idle
    window.dispatch_event('on_draw')
  File "C:\Python27\lib\site-packages\pyglet\window__init__.py", line 1219, in dispatch_event
    EventDispatcher.dispatch_event(self, _args)
  File "C:\Python27\lib\site-packages\pyglet\event.py", line 349, in dispatch_event
    return getattr(self, event_type)(_args)
  File "MCMain.py", line 434, in on_draw
    self.set_3d()
  File "MCMain.py", line 424, in set_3d
    gluPerspective(65.0, width / float(height), 0.1, 60.0)
ZeroDivisionError: float division by zero
