### PR TITLE
Fix jump

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,7 +376,7 @@ class Window(pyglet.window.Window):
             self.strafe[1] += 1
         elif symbol == key.SPACE:
             if self.dy == 0:
-                self.dy = 0.015 # jump speed
+                self.dy = 0.016 # jump speed
         elif symbol == key.ESCAPE:
             self.set_exclusive_mouse(False)
         elif symbol == key.TAB:


### PR DESCRIPTION
Jumping sometimes fails to bring you up enough to climb a block. Increasing slightly the jump speed fixes this.
