### PR TITLE
Add simple loading screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -484,6 +484,13 @@ class Window(pyglet.window.Window):
             x=10, y=self.height - 10, anchor_x='left', anchor_y='top',
             color=(0, 0, 0, 255))
 
+        # Boolean whether to display loading screen
+        self.is_initializing = True
+        # Loading screen label displayed in center of canvas
+        self.loading_label = pyglet.text.Label('', font_name='Arial', font_size=100,
+            x=self.width // 2, y=self.height // 2, anchor_x='center', anchor_y='center',
+            color=(0, 0, 0, 255))
+
         # This call schedules the `update()` method to be called
         # TICKS_PER_SEC. This is the main game event loop.
         pyglet.clock.schedule_interval(self.update, 1.0 / TICKS_PER_SEC)
@@ -803,13 +810,16 @@ class Window(pyglet.window.Window):
 
         """
         self.clear()
-        self.set_3d()
-        glColor3d(1, 1, 1)
-        self.model.batch.draw()
-        self.draw_focused_block()
+        if not self.is_initializing:
+            self.set_3d()
+            glColor3d(1, 1, 1)
+            self.model.batch.draw()
+            self.draw_focused_block()
+            self.set_2d()
+            self.draw_reticle()
         self.set_2d()
         self.draw_label()
-        self.draw_reticle()
+        self.is_initializing = False
 
     def draw_focused_block(self):
         """ Draw black edges around the block that is currently under the
@@ -830,18 +840,24 @@ class Window(pyglet.window.Window):
         """ Draw the label in the top left of the screen.
 
         """
-        x, y, z = self.position
-        self.label.text = '%02d (%.2f, %.2f, %.2f) %d / %d' % (
-            pyglet.clock.get_fps(), x, y, z,
-            len(self.model._shown), len(self.model.world))
-        self.label.draw()
+        if not self.is_initializing:
+            x, y, z = self.position
+            self.label.text = '%02d (%.2f, %.2f, %.2f) %d / %d' % (
+                pyglet.clock.get_fps(), x, y, z,
+                len(self.model._shown), len(self.model.world))
+            self.label.draw()
+        else:
+            # Only draw the loading screen during the first draw loop
+            self.loading_label.text = 'Loading...'
+            self.loading_label.draw()
 
     def draw_reticle(self):
         """ Draw the crosshairs in the center of the screen.
 
         """
-        glColor3d(0, 0, 0)
-        self.reticle.draw(GL_LINES)
+        if not self.is_initializing:
+            glColor3d(0, 0, 0)
+            self.reticle.draw(GL_LINES)
 
 
 def setup_fog():

--- a/main.py
+++ b/main.py
@@ -819,7 +819,9 @@ class Window(pyglet.window.Window):
             self.draw_reticle()
         self.set_2d()
         self.draw_label()
-        self.is_initializing = False
+        if self.is_initializing:
+            self.loading_label.delete()
+            self.is_initializing = False
 
     def draw_focused_block(self):
         """ Draw black edges around the block that is currently under the


### PR DESCRIPTION
It takes a long time to initially draw all the blocks, so I've added a simple "Loading..." label that covers the screen during the first draw loop.