### PR TITLE
Framerate Ticker and Command Line Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ cd Minecraft
 python main.py
 ```
 
+You may also use the optional "--fps" flag to display a framerate ticker in the bottom left corner of the window as so:
+
+```shell
+python main.py --fps
+```
+
 ### Mac
 
 On Mac OS X, you may have an issue with running Pyglet in 64-bit mode. Try running Python in 32-bit mode first:
@@ -55,15 +61,15 @@ arch -i386 python main.py
 If that doesn't work, set Python to run in 32-bit mode by default:
 
 ```shell
-defaults write com.apple.versioner.python Prefer-32-Bit -bool yes 
+defaults write com.apple.versioner.python Prefer-32-Bit -bool yes
 ```
 
 This assumes you are using the OS X default Python.  Works on Lion 10.7 with the default Python 2.7, and may work on other versions too.  Please raise an issue if not.
-    
+
 Or try Pyglet 1.2 alpha, which supports 64-bit mode:  
 
 ```shell
-pip install https://pyglet.googlecode.com/files/pyglet-1.2alpha1.tar.gz 
+pip install https://pyglet.googlecode.com/files/pyglet-1.2alpha1.tar.gz
 ```
 
 ### If you don't have pip or git

--- a/main.py
+++ b/main.py
@@ -505,10 +505,6 @@ class Window(pyglet.window.Window):
             x=10, y=self.height - 10, anchor_x='left', anchor_y='top',
             color=(0, 0, 0, 255))
 
-        # This call schedules the `update()` method to be called
-        # TICKS_PER_SEC. This is the main game event loop.
-        pyglet.clock.schedule_interval(self.update, 1.0 / TICKS_PER_SEC)
-
         if FRAMERATE:
             self.last_measured_framerate_time = time.time()
             # This tracks the amount of frames that
@@ -516,6 +512,10 @@ class Window(pyglet.window.Window):
             self.frames_passed = 0
             # This is our visible label for the frames
             self.framerate = pyglet.text.Label(text='Unknown', font_name='Verdana', font_size=8, x=10, y=10, color=(255,255,255,255))
+
+        # This call schedules the `update()` method to be called
+        # TICKS_PER_SEC. This is the main game event loop.
+        pyglet.clock.schedule_interval(self.update, 1.0 / TICKS_PER_SEC)
 
     def set_exclusive_mouse(self, exclusive):
         """ If `exclusive` is True, the game will capture the mouse, if False

--- a/main.py
+++ b/main.py
@@ -8,6 +8,27 @@ from pyglet.gl import *
 from pyglet.graphics import TextureGroup
 from pyglet.window import key, mouse
 
+""" GLOBAL PARAMETERS
+
+"""
+# Checks the command line arguments for flags that may be set.
+# Specifically, this looks at sys.argv, which is a list of
+# the file name, followed by each called argument.
+# It must be greater than 1 for there to exist any arguments
+# in the list, otherwise it will only contain the file name.
+from sys import argv
+FRAMERATE = False
+if argv and len(argv) > 1:
+
+    # The first argument of the list is not an argument,
+    # so we skip it using list slicing.
+    for command_line_argument in argv[1:]:
+
+        # The --fps command line argument will display the current
+        # framerate of the executed program.
+        if command_line_argument == '--fps':
+            FRAMERATE = True
+
 TICKS_PER_SEC = 60
 
 # Size of sectors used to ease block loading.
@@ -488,6 +509,14 @@ class Window(pyglet.window.Window):
         # TICKS_PER_SEC. This is the main game event loop.
         pyglet.clock.schedule_interval(self.update, 1.0 / TICKS_PER_SEC)
 
+        if FRAMERATE:
+            self.last_measured_framerate_time = time.time()
+            # This tracks the amount of frames that
+            # have passed since our last update.
+            self.frames_passed = 0
+            # This is our visible label for the frames
+            self.framerate = pyglet.text.Label(text='Unknown', font_name='Verdana', font_size=8, x=10, y=10, color=(255,255,255,255))
+
     def set_exclusive_mouse(self, exclusive):
         """ If `exclusive` is True, the game will capture the mouse, if False
         the game will ignore the mouse.
@@ -809,6 +838,8 @@ class Window(pyglet.window.Window):
         self.draw_focused_block()
         self.set_2d()
         self.draw_label()
+        if FRAMERATE:
+            self.draw_fps()
         self.draw_reticle()
 
     def draw_focused_block(self):
@@ -835,6 +866,19 @@ class Window(pyglet.window.Window):
             pyglet.clock.get_fps(), x, y, z,
             len(self.model._shown), len(self.model.world))
         self.label.draw()
+
+    def draw_fps(self):
+        """ Draw the fps measurement at the bottom left of the screen
+
+        """
+        if time.time() - self.last_measured_framerate_time >= 1:
+            self.framerate.text = str(self.frames_passed)
+            self.frames_passed = 0
+            self.last_measured_framerate_time = time.time()
+        else:
+            self.frames_passed += 1
+
+        self.framerate.draw()
 
     def draw_reticle(self):
         """ Draw the crosshairs in the center of the screen.


### PR DESCRIPTION
This commit implements a framerate ticker in the bottom left corner of the window.
It also allows for further extension of command line arguments.

I do believe this could be further refactored to use a module such as argparse, but I felt that as the goal of this project is to teach people how to code, the implementation of sys.argv was more suitable.
