### PR TITLE
Fix Issue #108 Use time.process_time() instead of time.clock()

### DIFF
--- a/main.py
+++ b/main.py
@@ -419,8 +419,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.process_time()
+        while self.queue and time.process_time() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
A pull request to the issue #108 