### PR TITLE
Replaced time.clock() with time.process_time()

### DIFF
--- a/main.py
+++ b/main.py
@@ -419,8 +419,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.process_time()
+        while self.queue and time.process_time() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
As of Python 3.3, time.clock() is deprecated,  I replaced that with time.process_time() method to make it work with the latest Python version.