### PR TITLE
time.clock() does not work for python 3.8 onwards.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import division
 
 import sys
@@ -419,8 +420,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.process_time()
+        while self.queue and time.process_time() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
Replaced it with time.process_time()