### PR TITLE
Fix the AttributError

### DIFF
--- a/main.py
+++ b/main.py
@@ -419,8 +419,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.perf_counter()
+        while self.queue and time.perf_counter() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
Since Python 3.3 time.clock() has been deprecated, if we are using
latest Python we have to change it to time.pref_counter(). For more
information:
https://www.geeksforgeeks.org/time-perf_counter-function-in-python/