### PR TITLE
[Fix] time.clock() deprecated in Python 3.8

### DIFF
--- a/main.py
+++ b/main.py
@@ -419,8 +419,8 @@ class Model(object):
         add_block() or remove_block() was called with immediate=False
 
         """
-        start = time.clock()
-        while self.queue and time.clock() - start < 1.0 / TICKS_PER_SEC:
+        start = time.perf_counter()
+        while self.queue and time.perf_counter() - start < 1.0 / TICKS_PER_SEC:
             self._dequeue()
 
     def process_entire_queue(self):


### PR DESCRIPTION
Replaced all calls to `time.clock()` with `time.perf_counter()`.

`time.clock()` has been removed from the `time` module in **Python 3.8**.

This PR closes #108 and makes the app executable again on Python 3.8+

Tested on my Windows machine with Python 3.8

Before the fix, the app was crashing unexpectedly with the following _Traceback_:
```
  File "main.py", line 902, in <module>
    main()
  File "main.py", line 898, in main
    pyglet.app.run()
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\pyglet\app\__init__.py", line 107, in run
    event_loop.run()
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\pyglet\app\base.py", line 167, in run
    timeout = self.idle()
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\pyglet\app\base.py", line 237, in idle
    redraw_all = self.clock.call_scheduled_functions(dt)
  File "C:\Users\***\AppData\Roaming\Python\Python38\site-packages\pyglet\clock.py", line 292, in call_scheduled_functions
    item.func(now - item.last_ts, *item.args, **item.kwargs)
  File "main.py", line 571, in update
    self.model.process_queue()
  File "main.py", line 422, in process_queue
    start = time.clock()
```