### PR TITLE
Add automatic checks of the pep8 using flake8 and Github Actions

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -1,0 +1,18 @@
+name: Flake8 Lint
+
+on: [push, pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.6"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v1
+

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ WALKING_SPEED = 5
 FLYING_SPEED = 15
 
 GRAVITY = 20.0
-MAX_JUMP_HEIGHT = 1.0 # About the height of a block.
+MAX_JUMP_HEIGHT = 1.0  # About the height of a block.
 # To derive the formula for calculating jump speed, first solve
 #    v_t = v_0 + a * t
 # for the time at which you achieve maximum height, where a is the acceleration
@@ -35,6 +35,7 @@ PLAYER_HEIGHT = 2
 
 if sys.version_info[0] >= 3:
     xrange = range
+
 
 def cube_vertices(x, y, z, n):
     """ Return the vertices of the cube at position x, y, z with size 2*n.
@@ -592,7 +593,7 @@ class Window(pyglet.window.Window):
         """
         # walking
         speed = FLYING_SPEED if self.flying else WALKING_SPEED
-        d = dt * speed # distance covered this tick.
+        d = dt * speed  # distance covered this tick.
         dx, dy, dz = self.get_motion_vector()
         # New position in space, before accounting for gravity.
         dx, dy, dz = dx * d, dy * d, dz * d

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+description-file = README.md
+
+[flake8]
+max-line-length = 100
+extend-exclude = env/*
+ignore =
+    E128,E201,E226,E231  # FIXME: use autopep8 on main.py
+    F403,F405  # FIXME: Can be removed when #124 is merged


### PR DESCRIPTION
Like #35, I believe that project is a great educational tool, an impressive achievement, and a reference for clean Python code.

Warnings F403 and F405 are currently ignored. That could be removed when #124 is merged.

Warnings E128,E201,E226,E231 could be removed if autopep8 or similar is used. I advise to merge #124 before, to limit the risk of merge conflict.

I fixed 3 small pep8 issues in main.py too.
