### PR TITLE
docs: fix simple typo, lenth -> length

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ class Model(object):
                         if (x - 0) ** 2 + (z - 0) ** 2 < 5 ** 2:
                             continue
                         self.add_block((x, y, z), t, immediate=False)
-                s -= d  # decrement side lenth so hills taper off
+                s -= d  # decrement side length so hills taper off
 
     def hit_test(self, position, vector, max_distance=8):
         """ Line of sight search from current position. If a block is


### PR DESCRIPTION
There is a small typo in main.py.

Should read `length` rather than `lenth`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md