### PR TITLE
Fix the bug that the character will automatically move backward.

### DIFF
--- a/main.py
+++ b/main.py
@@ -749,14 +749,16 @@ class Window(pyglet.window.Window):
             Number representing any modifying keys that were pressed.
 
         """
-        if symbol == key.W:
-            self.strafe[0] += 1
-        elif symbol == key.S:
-            self.strafe[0] -= 1
-        elif symbol == key.A:
-            self.strafe[1] += 1
-        elif symbol == key.D:
-            self.strafe[1] -= 1
+        self.strafe[0] = 0
+        self.strafe[1] = 0
+        # if symbol == key.W:
+        #     self.strafe[0] += 1
+        # elif symbol == key.S:
+        #     self.strafe[0] -= 1
+        # elif symbol == key.A:
+        #     self.strafe[1] += 1
+        # elif symbol == key.D:
+        #     self.strafe[1] -= 1
 
     def on_resize(self, width, height):
         """ Called when the window is resized to a new `width` and `height`.


### PR DESCRIPTION
Currently, I clone this repo and run it in my Windows 10 System. When I do nothing operation on the keyboard, the game character will move backward automatically. This seems to be a bug, and I have found and fixed it. Sincerely that you can merge my pull request.