### PR TITLE
Fixed typo in function sectorize()

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ def sectorize(position):
     """
     x, y, z = normalize(position)
     x, y, z = x // SECTOR_SIZE, y // SECTOR_SIZE, z // SECTOR_SIZE
-    return (x, 0, z)
+    return (x, y, z)
 
 
 class Model(object):


### PR DESCRIPTION
fixed typo '0' -> 'y' in sectorize() function so that y-value is correctly returned